### PR TITLE
feat: Add bulk insurance-state mapping upload for providers

### DIFF
--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -95,3 +95,9 @@ class ProviderUpdate(BaseModel):
                 "dedicated_link": "https://updated-link.com",
             }
         }
+
+
+class InsuranceStateUploadResponse(BaseModel):
+    mappings_added: int
+    skipped_rows: List[str] = []
+    message: str


### PR DESCRIPTION
## Summary
- Adds CSV upload functionality for bulk insurance-state mappings
- Implements progress indicator during file processing
- Enhances UI consistency with matching button colors

## Changes
1. **Backend API Enhancements**
   - New endpoint: `POST /api/provider/{provider_id}/upload-insurance-states`
   - CSV processing function to handle bulk data import
   - Validation for CSV format and data integrity
   - Automatic insurance provider creation if not exists

2. **Frontend Improvements**
   - Added CSV upload form in Update Provider page
   - Implemented progress indicator with spinner animation
   - Standardized button colors across the admin interface
   - Clear success/error messaging for upload results

3. **Data Model Updates**
   - Added `InsuranceStateUploadResponse` Pydantic model
   - Support for tracking added mappings and skipped rows

## Testing
- Tested with sample CSV files containing various insurance-state combinations
- Verified handling of duplicate entries and invalid data
- Confirmed progress indicator displays during processing

## Screenshots
The update provider page now includes:
- CSV upload section below provider details
- Progress spinner during file processing
- Consistent button styling throughout

🤖 Generated with [Claude Code](https://claude.ai/code)