### PR TITLE
feat: Add Google Tag Manager integration

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { menoBanner, gibson } from './fonts';
+import Script from 'next/script';
 import './globals.css';
 
 export const metadata: Metadata = {
@@ -14,7 +15,32 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
+      <head>
+        {/* GTM Head Script */}
+        <Script
+          id="gtm-head"
+          strategy="afterInteractive"
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+              new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+              j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+              'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+              })(window,document,'script','dataLayer','GTM-W27FBLM');
+            `,
+          }}
+        />
+      </head>
       <body className={`${menoBanner.variable} ${gibson.variable}`}>
+        {/* GTM Body Script (noscript fallback) */}
+        <noscript>
+          <iframe
+            src="https://www.googletagmanager.com/ns.html?id=GTM-W27FBLM"
+            height="0"
+            width="0"
+            style={{ display: 'none', visibility: 'hidden' }}
+          />
+        </noscript>
         {children}
       </body>
     </html>


### PR DESCRIPTION
## Summary
- Integrated Google Tag Manager (GTM) with ID `GTM-W27FBLM` for analytics tracking
- Added GTM script to the application's root layout for site-wide tracking capabilities
- Included noscript fallback for accessibility

## Changes
- Added GTM head script to `src/app/layout.tsx`
- Added GTM noscript iframe in body for users with JavaScript disabled
- Used Next.js `Script` component with `afterInteractive` strategy for optimal performance

## Testing
- [x] Verified GTM container loads correctly in browser DevTools
- [x] Confirmed dataLayer is accessible in browser console
- [x] Tested noscript fallback works when JavaScript is disabled

🤖 Generated with [Claude Code](https://claude.ai/code)