### PR TITLE
fix: Prevent duplicate click tracking for auto-redirect and manual clicks

### DIFF
--- a/TEST_ENVIRONMENT.md
+++ b/TEST_ENVIRONMENT.md
@@ -1,0 +1,161 @@
+# Test Environment Setup
+
+This document describes the test environment for click tracking analytics.
+
+## Test Database Tables
+
+The following test tables have been created as duplicates of the production tables:
+
+### 1. `test_provider_clicks`
+- **Purpose**: Test version of `provider_clicks` table
+- **Foreign Key**: References `test_providers(id)` with CASCADE delete
+- **Indexes**: Same as production for performance testing
+- **Schema**: Identical to `provider_clicks`
+
+### 2. `test_providers`
+- **Purpose**: Test providers data
+- **Status**: Already existed in database
+- **Note**: Use this for creating test provider records
+
+### 3. `test_insurances`
+- **Purpose**: Test insurance providers
+- **Status**: Already existed in database
+
+### 4. `test_provider_coverage`
+- **Purpose**: Test provider coverage data
+- **Status**: Already existed in database
+
+## Test RPC Functions
+
+### `test_get_click_analytics()`
+- **Purpose**: Analytics function for test click data
+- **Parameters**:
+  - `start_date` (DATE, default: 30 days ago)
+  - `end_date` (DATE, default: today)
+  - `provider_id_filter` (INTEGER, optional)
+  - `state_filter` (VARCHAR(2), optional)
+- **Returns**: Same structure as `get_click_analytics()`
+
+## Environment Variables
+
+To use the test environment, add these environment variables to your `.env` file:
+
+### Backend Environment Variables
+
+```bash
+# Test Tables (add these to backend/.env)
+TEST_PROVIDER_CLICKS_TABLE=test_provider_clicks
+TEST_PROVIDERS_TABLE=test_providers
+TEST_INSURANCES_TABLE=test_insurances
+TEST_PROVIDER_COVERAGE_TABLE=test_provider_coverage
+
+# Test RPC Functions
+TEST_GET_CLICK_ANALYTICS=test_get_click_analytics
+TEST_SEARCH_PROVIDERS=test_search_providers  # You may need to create this
+
+# Environment Toggle (set to 'test' to use test tables)
+APP_ENVIRONMENT=production  # or 'test'
+```
+
+### Frontend Environment Variables
+
+```bash
+# Add to .env.local for frontend testing
+NEXT_PUBLIC_USE_TEST_ENVIRONMENT=false  # Set to 'true' for testing
+```
+
+## Usage
+
+### Option 1: Environment Variable Toggle (Recommended)
+
+Modify your backend code to check the `APP_ENVIRONMENT` variable:
+
+```python
+# In backend/app/api/routes.py
+import os
+
+# Determine which tables to use based on environment
+ENVIRONMENT = os.getenv("APP_ENVIRONMENT", "production")
+
+if ENVIRONMENT == "test":
+    PROVIDER_CLICKS_TABLE = os.getenv("TEST_PROVIDER_CLICKS_TABLE")
+    PROVIDERS_TABLE = os.getenv("TEST_PROVIDERS_TABLE")
+    GET_CLICK_ANALYTICS_FUNC = os.getenv("TEST_GET_CLICK_ANALYTICS")
+else:
+    PROVIDER_CLICKS_TABLE = os.getenv("PROVIDER_CLICKS_TABLE")
+    PROVIDERS_TABLE = os.getenv("PROVIDERS_TABLE")
+    GET_CLICK_ANALYTICS_FUNC = "get_click_analytics"
+```
+
+### Option 2: Separate Test Endpoints
+
+Create dedicated test endpoints:
+
+```python
+@router.post("/test/track-click", response_model=ClickTrackingResponse)
+async def test_track_provider_click(request: ClickTrackingRequest):
+    # Use TEST_PROVIDER_CLICKS_TABLE
+    ...
+
+@router.post("/test/analytics/clicks", response_model=List[ClickAnalytics])
+async def test_get_click_analytics(request: ClickAnalyticsRequest):
+    # Use test_get_click_analytics RPC
+    ...
+```
+
+## Testing the Duplicate Click Fix
+
+To test the duplicate click tracking fix in the test environment:
+
+1. **Set environment to test mode**:
+   ```bash
+   # backend/.env
+   APP_ENVIRONMENT=test
+   ```
+
+2. **Add test data**:
+   ```sql
+   -- Add a test provider to test_providers
+   INSERT INTO test_providers (name, phone, email, dedicated_link)
+   VALUES ('Test Breastpumps.com', '555-0100', 'test@example.com', 'https://test.example.com');
+   ```
+
+3. **Test the flow**:
+   - Perform a search that triggers auto-redirect
+   - Verify only ONE click is tracked (auto_redirect)
+   - Manual clicks on the same provider should be prevented
+   - Check `test_provider_clicks` table for results
+
+4. **Verify analytics**:
+   ```sql
+   -- Check test analytics
+   SELECT * FROM test_get_click_analytics();
+   ```
+
+## Cleanup
+
+To remove test data without affecting production:
+
+```sql
+-- Clear all test clicks
+TRUNCATE test_provider_clicks CASCADE;
+
+-- Or delete specific test session
+DELETE FROM test_provider_clicks WHERE session_id = 'your_test_session_id';
+```
+
+## Migration to Production
+
+Once testing is complete and you're satisfied with the results:
+
+1. Set `APP_ENVIRONMENT=production` in backend `.env`
+2. Restart the backend server
+3. The same code will now use production tables
+4. Monitor production analytics for accuracy
+
+## Notes
+
+- Test tables share the same database as production
+- Be careful not to mix test and production data
+- Always verify which environment you're using before testing
+- Consider adding a visual indicator in the UI when using test mode

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,6 +26,7 @@ export default function Home() {
   const [isBreastpumpsFlow, setIsBreastpumpsFlow] = useState(false);
   const [loadingStatus, setLoadingStatus] = useState<string>('Processing your request...');
   const [searchData, setSearchData] = useState<any>(null); // Store search context
+  const [trackedProviders, setTrackedProviders] = useState<Set<number>>(new Set()); // Track which providers have been clicked/tracked
 
   useEffect(() => {
     // Fetch states data
@@ -52,6 +53,9 @@ export default function Home() {
     setError(null);
     setIsBreastpumpsFlow(false);
     setLoadingStatus('Processing your request...');
+
+    // Reset tracked providers for new search
+    setTrackedProviders(new Set());
 
     // Store search context for click tracking
     const sessionId = getSessionId();
@@ -99,6 +103,8 @@ export default function Home() {
             click_type: 'auto_redirect',
             session_id: sessionId,
           });
+          // Mark this provider as already tracked
+          setTrackedProviders(prev => new Set(prev).add(breastpumpsProviderId));
         }
         
         try {
@@ -305,7 +311,7 @@ export default function Home() {
                 </button>
               </div>
             ) : (
-              <ResultsList results={results} searchData={searchData} />
+              <ResultsList results={results} searchData={searchData} trackedProviders={trackedProviders} onProviderTracked={(providerId) => setTrackedProviders(prev => new Set(prev).add(providerId))} />
             )}
           </div>
         </main>


### PR DESCRIPTION
## Summary
Fixed an issue where auto-redirect clicks were being tracked twice when the WordPress API call failed and users manually clicked the same provider. This was causing confusion in analytics metrics, inflating both manual and auto-redirect counts.

## Problem
When a search triggered an auto-redirect to breastpumps.com but the WordPress API call failed, the following sequence occurred:
1. Auto-redirect click was tracked with `click_type: 'auto_redirect'` ✅
2. Results list was displayed to the user (fallback behavior)
3. User manually clicked on breastpumps.com again
4. Manual click was tracked with `click_type: 'manual'` ❌

This resulted in the same provider being tracked twice in the same search session, confusing the metrics.

## Solution
Implemented session-based duplicate prevention:
- Added `trackedProviders` state to track which provider IDs have been tracked in the current search session
- Reset `trackedProviders` on each new search
- Mark providers as tracked immediately after auto-redirect tracking
- Pass tracked state to `ResultsList` component
- Skip tracking if provider already tracked in session

## Changes
- **[src/app/page.tsx](src/app/page.tsx)**
  - Added `trackedProviders` state (Set of provider IDs)
  - Reset tracking state on new search
  - Mark auto-redirect providers as tracked
  - Pass tracking props to ResultsList

- **[src/app/components/ResultsList.tsx](src/app/components/ResultsList.tsx)**
  - Accept `trackedProviders` and `onProviderTracked` props
  - Check for duplicate tracking before API call
  - Mark provider as tracked before making request
  - Added console logging for skipped duplicates

- **[TEST_ENVIRONMENT.md](TEST_ENVIRONMENT.md)**
  - Comprehensive test environment documentation
  - Created `test_provider_clicks` table in Supabase
  - Created `test_get_click_analytics()` RPC function
  - Usage instructions and testing procedures

## Testing
- Test environment created with duplicate tables (`test_provider_clicks`, `test_get_click_analytics()`)
- Can test the fix safely without affecting production analytics
- See [TEST_ENVIRONMENT.md](TEST_ENVIRONMENT.md) for setup instructions

## Benefits
✅ Accurate separation of manual vs auto-redirect metrics  
✅ No double-counting within search sessions  
✅ Maintains user experience (no blocking)  
✅ Console logging for debugging

🤖 Generated with [Claude Code](https://claude.com/claude-code)